### PR TITLE
ci: scope release env and OIDC permissions to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,15 +97,43 @@ jobs:
           run: poetry run pytest --no-cov -vvvvv --codspeed tests/benchmarks
           mode: instrumentation
 
+  # Dry run on PRs and non-main pushes. No environment, no publish
+  # permissions, no OIDC, so PR runs carry no release blast radius.
+  release-dry-run:
+    needs:
+      - test
+      - lint
+      - commitlint
+    if: github.ref_name != 'main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.ref }}
+      - name: Create local branch name
+        env:
+          BRANCH: ${{ github.head_ref || github.ref_name }}
+        run: git switch -C "$BRANCH"
+      - name: Test release
+        uses: python-semantic-release/python-semantic-release@4d4cb0ab842247caea1963132c242c62aab1e4d5 # v10.4.1
+        with:
+          no_operation_mode: true
+
+  # Real release, only on main. The release environment and write/OIDC
+  # permissions are scoped to this job so they never apply to PR runs.
   release:
     needs:
       - test
       - lint
       - commitlint
-
+    if: github.ref_name == 'main'
     runs-on: ubuntu-latest
     environment: release
-    concurrency: release
+    concurrency:
+      group: release-${{ github.ref }}
     permissions:
       id-token: write
       contents: write
@@ -117,20 +145,17 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v4
         with:
           fetch-depth: 0
-          ref: ${{ github.head_ref || github.ref_name }}
+          ref: ${{ github.ref }}
 
-      # Do a dry run of PSR
-      - name: Test release
-        uses: python-semantic-release/python-semantic-release@4d4cb0ab842247caea1963132c242c62aab1e4d5 # v10.4.1
-        if: github.ref_name != 'main'
-        with:
-          no_operation_mode: true
+      - name: Create local branch name
+        env:
+          BRANCH: ${{ github.ref_name }}
+        run: git switch -C "$BRANCH"
 
       # On main branch: actual PSR + upload to PyPI & GitHub
       - name: Release
         uses: python-semantic-release/python-semantic-release@4d4cb0ab842247caea1963132c242c62aab1e4d5 # v10.4.1
         id: release
-        if: github.ref_name == 'main'
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary

The release job held id-token: write, contents: write, and the release environment on every trigger including pull requests, even though it only published on main; this splits it into two jobs so PR runs no longer carry release credentials.

## Details

release-dry-run runs on PRs and non-main pushes with only contents: read, no environment and no OIDC, just the python-semantic-release dry run; release runs only on main and keeps the release environment plus write and OIDC permissions scoped to that job, so they never apply to untrusted PR code.

## Test plan

- [ ] workflow YAML parses clean
- [ ] dry-run job runs on this PR, publish job stays skipped
